### PR TITLE
add notice about install prerequisites

### DIFF
--- a/linux/dsrtools/INSTALL
+++ b/linux/dsrtools/INSTALL
@@ -1,10 +1,11 @@
 These packages supply the dsrtools software that provides control
 of L2DSR and L3DSR VIPs.
 
+Consult the 'Requires' and 'BuildRequires' entries in the "rpm/dsrtools.spec" regarding the prerequisites. On RHEL systems, you may find useful to yum groupinstall "Development Tools" (and "RPM Development Tools" on rhel8).
+
 To build the software, type:
 
     $ make
-
 
 For RPM-based distros, to build the source package, type:
 

--- a/linux/iptables-daddr/INSTALL
+++ b/linux/iptables-daddr/INSTALL
@@ -1,6 +1,8 @@
 These packages supply an Iptables plugin and kernel module and that
 allow rewriting of the destination IP address for IPv4 and IPv6.
 
+Consult the 'Requires' and 'BuildRequires' entries in the "rpm/iptables-daddr.spec" regarding the prerequisites. On RHEL systems, you may find useful to yum groupinstall "Development Tools"` (and "RPM Development Tools" on rhel8).
+
 To build both components of the software, type:
 
     $ make


### PR DESCRIPTION
add notice about installing rpmbuild with rpm-build package as 
prerequisite for building RPMs.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
