### PR TITLE
mock changes for RHEL 8

### DIFF
--- a/linux/iptables-daddr/mock/Makefile
+++ b/linux/iptables-daddr/mock/Makefile
@@ -6,6 +6,7 @@
 #   DIST			%{dist} for rpmbuild or '""' for unsetting it
 #   MOCK_SRPM_RESULTDIR		--resultdir for building SRPM
 #   MOCK_RPM_RESULTDIR		--resultdir for building RPMs
+#   EXTRA_MOCK_PACKAGES   extra mock packages for --install
 #   EXTRA_MOCK_SRPM_ARGS	extra mock arguments when building SRPM
 #   EXTRA_MOCK_RPM_ARGS		extra mock arguments when building RPMs
 #
@@ -44,7 +45,7 @@ sourcesfiles = $(addprefix $(sources)/,$(extrasrcfiles))
 
 kernel-devel          = kernel-devel$(if $(KVERREL),-$(KVERREL))
 kernel-abi-whitelists = kernel-abi-whitelists$(if $(KVERREL),-$(KVERREL))
-install_pkgs          = $(kernel-devel) $(kernel-abi-whitelists)
+install_pkgs          = $(kernel-devel) $(kernel-abi-whitelists) $(EXTRA_MOCK_PACKAGES)
 
 rpmpkgs  := $(shell \
 	$(MOCK) $(mock_srpm_args) --quiet \

--- a/linux/iptables-daddr/rpm/iptables-daddr.spec
+++ b/linux/iptables-daddr/rpm/iptables-daddr.spec
@@ -61,6 +61,9 @@ BuildRequires: module-init-tools
     %else
 BuildRequires: kmod
     %endif
+    %if 0%{?rhel} > 7
+BuildRequires: kernel-rpm-macros
+    %endif
 BuildRequires: redhat-rpm-config >= 9.0.3-42
 BuildRequires: kernel-devel
   %endif


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Building in RHEL 8 requires including `kernel-rpm-macros` in mock's `--install` list. 